### PR TITLE
Updated build.command to specifically work with Apple's Clang

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -22494,6 +22494,7 @@ void sub_put2(int32 i,int64 offset,void *element,int32 passed){
                     if ( (err) != noErr ) goto CantGetPasteboardItemIdentifier;
                     
                     err = PasteboardCopyItemFlavorData( inPasteboard, itemID, CFSTR("public.utf8-plain-text"), &flavorData );      
+                    if ( (err) != noErr ) goto CantGetPasteboardItemCount;
                     data = (char*)CFDataGetBytePtr(flavorData);
                     
                     uint32 size;

--- a/internal/c/parts/audio/out/os/osx/build.command
+++ b/internal/c/parts/audio/out/os/osx/build.command
@@ -1,32 +1,32 @@
 cd "$(dirname "$0")"
-gcc -s -c -w -Wall ../../src/coreaudio.c -D AL_LIBTYPE_STATIC -o temp/coreaudio.o
-gcc -s -c -w -Wall ../../src/helpers.c -D AL_LIBTYPE_STATIC -o temp/helpers.o
-gcc -s -c -w -Wall ../../src/bs2b.c -D AL_LIBTYPE_STATIC -o temp/bs2b.o
-gcc -s -c -w -Wall ../../src/alAuxEffectSlot.c -D AL_LIBTYPE_STATIC -o temp/alAuxEffectSlot.o
-gcc -s -c -w -Wall ../../src/alBuffer.c -D AL_LIBTYPE_STATIC -o temp/alBuffer.o
-gcc -s -c -w -Wall ../../src/ALc.c -D AL_LIBTYPE_STATIC -o temp/ALc.o
-gcc -s -c -w -Wall ../../src/alcConfig.c -D AL_LIBTYPE_STATIC -o temp/alcConfig.o
-gcc -s -c -w -Wall ../../src/alcDedicated.c -D AL_LIBTYPE_STATIC -o temp/alcDedicated.o
-gcc -s -c -w -Wall ../../src/alcEcho.c -D AL_LIBTYPE_STATIC -o temp/alcEcho.o
-gcc -s -c -w -Wall ../../src/alcModulator.c -D AL_LIBTYPE_STATIC -o temp/alcModulator.o
-gcc -s -c -w -Wall ../../src/alcReverb.c -D AL_LIBTYPE_STATIC -o temp/alcReverb.o
-gcc -s -c -w -Wall ../../src/alcRing.c -D AL_LIBTYPE_STATIC -o temp/alcRing.o
-gcc -s -c -w -Wall ../../src/alcThread.c -D AL_LIBTYPE_STATIC -o temp/alcThread.o
-gcc -s -c -w -Wall ../../src/alEffect.c -D AL_LIBTYPE_STATIC -o temp/alEffect.o
-gcc -s -c -w -Wall ../../src/alError.c -D AL_LIBTYPE_STATIC -o temp/alError.o
-gcc -s -c -w -Wall ../../src/alExtension.c -D AL_LIBTYPE_STATIC -o temp/alExtension.o
-gcc -s -c -w -Wall ../../src/alFilter.c -D AL_LIBTYPE_STATIC -o temp/alFilter.o
-gcc -s -c -w -Wall ../../src/alListener.c -D AL_LIBTYPE_STATIC -o temp/alListener.o
-gcc -s -c -w -Wall ../../src/alSource.c -D AL_LIBTYPE_STATIC -o temp/alSource.o
-gcc -s -c -w -Wall ../../src/alState.c -D AL_LIBTYPE_STATIC -o temp/alState.o
-gcc -s -c -w -Wall ../../src/alThunk.c -D AL_LIBTYPE_STATIC -o temp/alThunk.o
-gcc -s -c -w -Wall ../../src/ALu.c -D AL_LIBTYPE_STATIC -o temp/ALu.o
-gcc -s -c -w -Wall ../../src/hrtf.c -D AL_LIBTYPE_STATIC -o temp/hrtf.o
-gcc -s -c -w -Wall ../../src/loopback.c -D AL_LIBTYPE_STATIC -o temp/loopback.o
-gcc -s -c -w -Wall ../../src/mixer.c -D AL_LIBTYPE_STATIC -o temp/mixer.o
-gcc -s -c -w -Wall ../../src/null.c -D AL_LIBTYPE_STATIC -o temp/null.o
-gcc -s -c -w -Wall ../../src/panning.c -D AL_LIBTYPE_STATIC -o temp/panning.o
-gcc -s -c -w -Wall ../../src/wave.c -D AL_LIBTYPE_STATIC -o temp/wave.o
+clang -s -c -w -Wall ../../src/coreaudio.c -D AL_LIBTYPE_STATIC -o temp/coreaudio.o
+clang -s -c -w -Wall ../../src/helpers.c -D AL_LIBTYPE_STATIC -o temp/helpers.o
+clang -s -c -w -Wall ../../src/bs2b.c -D AL_LIBTYPE_STATIC -o temp/bs2b.o
+clang -s -c -w -Wall ../../src/alAuxEffectSlot.c -D AL_LIBTYPE_STATIC -o temp/alAuxEffectSlot.o
+clang -s -c -w -Wall ../../src/alBuffer.c -D AL_LIBTYPE_STATIC -o temp/alBuffer.o
+clang -s -c -w -Wall ../../src/ALc.c -D AL_LIBTYPE_STATIC -o temp/ALc.o
+clang -s -c -w -Wall ../../src/alcConfig.c -D AL_LIBTYPE_STATIC -o temp/alcConfig.o
+clang -s -c -w -Wall ../../src/alcDedicated.c -D AL_LIBTYPE_STATIC -o temp/alcDedicated.o
+clang -s -c -w -Wall ../../src/alcEcho.c -D AL_LIBTYPE_STATIC -o temp/alcEcho.o
+clang -s -c -w -Wall ../../src/alcModulator.c -D AL_LIBTYPE_STATIC -o temp/alcModulator.o
+clang -s -c -w -Wall ../../src/alcReverb.c -D AL_LIBTYPE_STATIC -o temp/alcReverb.o
+clang -s -c -w -Wall ../../src/alcRing.c -D AL_LIBTYPE_STATIC -o temp/alcRing.o
+clang -s -c -w -Wall ../../src/alcThread.c -D AL_LIBTYPE_STATIC -o temp/alcThread.o
+clang -s -c -w -Wall ../../src/alEffect.c -D AL_LIBTYPE_STATIC -o temp/alEffect.o
+clang -s -c -w -Wall ../../src/alError.c -D AL_LIBTYPE_STATIC -o temp/alError.o
+clang -s -c -w -Wall ../../src/alExtension.c -D AL_LIBTYPE_STATIC -o temp/alExtension.o
+clang -s -c -w -Wall ../../src/alFilter.c -D AL_LIBTYPE_STATIC -o temp/alFilter.o
+clang -s -c -w -Wall ../../src/alListener.c -D AL_LIBTYPE_STATIC -o temp/alListener.o
+clang -s -c -w -Wall ../../src/alSource.c -D AL_LIBTYPE_STATIC -o temp/alSource.o
+clang -s -c -w -Wall ../../src/alState.c -D AL_LIBTYPE_STATIC -o temp/alState.o
+clang -s -c -w -Wall ../../src/alThunk.c -D AL_LIBTYPE_STATIC -o temp/alThunk.o
+clang -s -c -w -Wall ../../src/ALu.c -D AL_LIBTYPE_STATIC -o temp/ALu.o
+clang -s -c -w -Wall ../../src/hrtf.c -D AL_LIBTYPE_STATIC -o temp/hrtf.o
+clang -s -c -w -Wall ../../src/loopback.c -D AL_LIBTYPE_STATIC -o temp/loopback.o
+clang -s -c -w -Wall ../../src/mixer.c -D AL_LIBTYPE_STATIC -o temp/mixer.o
+clang -s -c -w -Wall ../../src/null.c -D AL_LIBTYPE_STATIC -o temp/null.o
+clang -s -c -w -Wall ../../src/panning.c -D AL_LIBTYPE_STATIC -o temp/panning.o
+clang -s -c -w -Wall ../../src/wave.c -D AL_LIBTYPE_STATIC -o temp/wave.o
 ar rcs src.a temp/alAuxEffectSlot.o temp/alBuffer.o temp/ALc.o temp/alcConfig.o temp/alcDedicated.o temp/alcEcho.o temp/alcModulator.o temp/alcReverb.o temp/alcRing.o temp/alcThread.o temp/alEffect.o temp/alError.o temp/alExtension.o temp/alFilter.o temp/alListener.o temp/coreaudio.o temp/alSource.o temp/alState.o temp/alThunk.o temp/ALu.o temp/hrtf.o temp/loopback.o temp/mixer.o temp/null.o temp/panning.o temp/wave.o temp/helpers.o temp/bs2b.o
 echo "Press any key to continue..."
 Pause()
@@ -44,28 +44,28 @@ Pause
 
 
 ####### added for OSX (above)
-gcc -s -c -w -Wall ../../src/coreaudio.c -D AL_LIBTYPE_STATIC -o temp/coreaudio.o
+clang -s -c -w -Wall ../../src/coreaudio.c -D AL_LIBTYPE_STATIC -o temp/coreaudio.o
 
 
 ###### removed for osx
-gcc -s -c -w -Wall ../../src/alsa.c -D AL_LIBTYPE_STATIC -o temp/alsa.o
+clang -s -c -w -Wall ../../src/alsa.c -D AL_LIBTYPE_STATIC -o temp/alsa.o
 
 
 ####Compiled but unrequired (using ALSA instead)####
-gcc -s -c -w -Wall ../../src/oss.c -D AL_LIBTYPE_STATIC -o temp/oss.o
+clang -s -c -w -Wall ../../src/oss.c -D AL_LIBTYPE_STATIC -o temp/oss.o
 temp/oss.o
-gcc -s -c -w -Wall ../../src/pulseaudio.c -D AL_LIBTYPE_STATIC -o temp/pulseaudio.o
+clang -s -c -w -Wall ../../src/pulseaudio.c -D AL_LIBTYPE_STATIC -o temp/pulseaudio.o
 temp/pulseaudio.o
 
 ####These all failed to compile in Ubuntu####
-gcc -s -c -w -Wall ../../src/solaris.c -D AL_LIBTYPE_STATIC -o temp/solaris.o
-gcc -s -c -w -Wall ../../src/sndio.c -D AL_LIBTYPE_STATIC -o temp/sndio.o
-gcc -s -c -w -Wall ../../src/portaudio.c -D AL_LIBTYPE_STATIC -o temp/portaudio.o
-gcc -s -c -w -Wall ../../src/coreaudio.c -D AL_LIBTYPE_STATIC -o temp/coreaudio.o
-gcc -s -c -w -Wall ../../src/opensl.c -D AL_LIBTYPE_STATIC -o temp/opensl.o
+clang -s -c -w -Wall ../../src/solaris.c -D AL_LIBTYPE_STATIC -o temp/solaris.o
+clang -s -c -w -Wall ../../src/sndio.c -D AL_LIBTYPE_STATIC -o temp/sndio.o
+clang -s -c -w -Wall ../../src/portaudio.c -D AL_LIBTYPE_STATIC -o temp/portaudio.o
+clang -s -c -w -Wall ../../src/coreaudio.c -D AL_LIBTYPE_STATIC -o temp/coreaudio.o
+clang -s -c -w -Wall ../../src/opensl.c -D AL_LIBTYPE_STATIC -o temp/opensl.o
 
 ####These are Windows specific####
-gcc -s -c -w -Wall ../../src/dsound.c -D AL_LIBTYPE_STATIC -o temp/dsound.o
-gcc -s -c -w -Wall ../../src/mmdevapi.c -D AL_LIBTYPE_STATIC -o temp/mmdevapi.o
-gcc -s -c -w -Wall ../../src/winmm.c -D AL_LIBTYPE_STATIC -o temp/winmm.o
+clang -s -c -w -Wall ../../src/dsound.c -D AL_LIBTYPE_STATIC -o temp/dsound.o
+clang -s -c -w -Wall ../../src/mmdevapi.c -D AL_LIBTYPE_STATIC -o temp/mmdevapi.o
+clang -s -c -w -Wall ../../src/winmm.c -D AL_LIBTYPE_STATIC -o temp/winmm.o
 

--- a/source/global/version.bas
+++ b/source/global/version.bas
@@ -2,8 +2,8 @@ DIM SHARED Version AS STRING
 DIM SHARED BuildNum AS STRING
 DIM SHARED AutoBuildMsg AS STRING
 
-Version$ = "1.4"
-BuildNum$ = "Stable Release"
+Version$ = "1.5"
+BuildNum$ = "(development build)"
 IF _FILEEXISTS("internal/version.txt") THEN
     versionfile = FREEFILE
     OPEN "internal/version.txt" FOR INPUT AS #versionfile

--- a/source/icon.rc
+++ b/source/icon.rc
@@ -1,8 +1,8 @@
 0 ICON "qb64.ico"
 
 1 VERSIONINFO
-FILEVERSION     1,4,0,0
-PRODUCTVERSION  1,4,0,0
+FILEVERSION     1,5,0,0
+PRODUCTVERSION  1,5,0,0
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
@@ -10,13 +10,13 @@ BEGIN
         BEGIN
             VALUE "CompanyName","QB64\0"
             VALUE "FileDescription","QB64 Compiler\0"
-            VALUE "FileVersion","1.4\0"
+            VALUE "FileVersion","1.5\0"
             VALUE "InternalName","qb64.bas\0"
             VALUE "LegalCopyright","LGPL\0"
             VALUE "LegalTrademarks","\0"
             VALUE "OriginalFilename","qb64.exe\0"
             VALUE "ProductName","QB64\0"
-            VALUE "ProductVersion","1.4\0"
+            VALUE "ProductVersion","1.5\0"
             VALUE "Comments","QB64 is a modern extended BASIC programming language that retains QB4.5/QBasic compatibility and compiles native binaries for Windows, Linux and macOS.\0"
         END
     END

--- a/source/icon.rc
+++ b/source/icon.rc
@@ -1,8 +1,8 @@
 0 ICON "qb64.ico"
 
 1 VERSIONINFO
-FILEVERSION     1,3,0,0
-PRODUCTVERSION  1,3,0,0
+FILEVERSION     1,4,0,0
+PRODUCTVERSION  1,4,0,0
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
@@ -10,14 +10,14 @@ BEGIN
         BEGIN
             VALUE "CompanyName","QB64\0"
             VALUE "FileDescription","QB64 Compiler\0"
-            VALUE "FileVersion","1.3\0"
+            VALUE "FileVersion","1.4\0"
             VALUE "InternalName","qb64.bas\0"
             VALUE "LegalCopyright","LGPL\0"
             VALUE "LegalTrademarks","\0"
             VALUE "OriginalFilename","qb64.exe\0"
             VALUE "ProductName","QB64\0"
-            VALUE "ProductVersion","1.3\0"
-            VALUE "Comments","QB64 is a modern extended BASIC programming language that retains QB4.5/Qbasic compatibility and compiles native binaries for Windows, Linux and macOS.\0"
+            VALUE "ProductVersion","1.4\0"
+            VALUE "Comments","QB64 is a modern extended BASIC programming language that retains QB4.5/QBasic compatibility and compiles native binaries for Windows, Linux and macOS.\0"
         END
     END
 


### PR DESCRIPTION
Fixed an issue where Apple's Clang is forcefully used instead of GCC for compiling QB64 applications. (Fixes issues for those using true GCC via Homebrew and not Clang that just has a symlink of GCC).