### PR TITLE
Possible fix for qb45 converter

### DIFF
--- a/source/utilities/QB45BIN.bas
+++ b/source/utilities/QB45BIN.bas
@@ -435,7 +435,7 @@ DATA 0x045,*,"deffn::={#procdecl:2}"
 DATA 0x046,"DO"
 DATA 0x047,"DO UNTIL {0}"
 DATA 0x048,2,"DO WHILE {0}"
-DATA 0x049,2,"{newline:0}ELSE| ELSE "
+DATA 0x049,2,"{newline:0}ELSE | ELSE "
 
 ' 0x04a = implicit GOTO linenumber used in 0x04c ELSE
 DATA 0x04a,2,"{#id}"
@@ -570,7 +570,7 @@ DATA 0x09f,"CIRCLE {##circle-args}"
 DATA 0x0a0,"CIRCLE {##circle-args}"
 DATA 0x0a1,2,"CLEAR{##varargs}"
 DATA 0x0a2,2,"CLOSE{##varargs}"
-DATA 0x0a3,"CLS {expr:0}|CLS"
+DATA 0x0a3,"CLS {expr:0}|CLS "
 DATA 0x0a4,2,"COLOR{##varargs}"
 
 DATA 0x0a5,4,"decl::=COMMON {declmod:0}{#blockname:2}"


### PR DESCRIPTION
Hello!

Now that the qb64 converter is working for me on mac, I decided to cross-check it against an export I did against the original qb45.exe tool.  I noticed 3 small differences.  I was able to make 2 small changes to address 2 of the changes, and of the two, one of them appears to be significantly important enough for inclusion.

Here are the 3 comparisons:
Fix 1 (the important one, included):
QB45 output:
`ELSE GOTO Check`
QB64 output:
`ELSEGOTO Check`
The space is missing, which without it, we have an invalid keyword.

Fix 2 (less important, but included):
QB45 output (2 examples):
`COLOR 7, 0: CLS : END`
`IF K$ = "Q" OR K$ = "q" THEN COLOR 7, 0: CLS : END`
QB64 output (2 examples):
`COLOR 7, 0: CLS: END`
`IF K$ = "Q" OR K$ = "q" THEN COLOR 7, 0: CLS: END`
Basically, there's a space missing after the CLS but before the colon.
I'm not sure how important this is, but I think it was easy enough to find and I made the change to make it consistent with an original QB45 export.

Fix 3 (unsolved):
QB45 output:
`LOCATE 2, 8: COLOR 14, 3: PRINT SIZE; " Kb "; : COLOR 0, 0: PRINT "  "`
QB64 output:
`LOCATE 2, 8: COLOR 14, 3: PRINT SIZE; " Kb ";: COLOR 0, 0: PRINT "  "`
Basically, a space is missing between the ";" and the ":".
I couldn't figure out how to solve this one to make it match, and I wasn't sure it mattered.  But, I wanted to log it as a notable difference since I'm not sure how often the converter is tested.  Perhaps this will be useful feedback.

Anyway, these are my fixes.  I can't tell if these changes impact conversions in any negative way, but I wanted to share the code I found to try to reduce development burden.  Please let me know if you need any more info.  Thanks!