### PR TITLE
Create qb64.desktop

### DIFF
--- a/qb64.desktop
+++ b/qb64.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=QB64 Programming IDE
+GenericName=QB64 Programming IDE
+Exec=qb64
+Icon=qb64icon32
+Terminal=false
+Type=Application
+Categories=Development;IDE;
+StartupNotify=false


### PR DESCRIPTION
This is the system wide installation desktop file, to be installed to /usr/share/applications/ and the icon should go to /usr/share/icons/