### PR TITLE
Set scale_factor=2 only if both Retina and 5K

### DIFF
--- a/internal/c/libqb/gui.cpp
+++ b/internal/c/libqb/gui.cpp
@@ -554,7 +554,7 @@ void sub__glrender(int32 method){
                         }
                         pclose(consoleStream);
 
-                        if (b_isRetina || b_is5k) {
+                        if (b_isRetina && b_is5k) {
                             // apply only factor = 2 if macOS is Catalina (11.15.* // kern.osrelease 19.*)
                             char str[256];
                             size_t size = sizeof(str);


### PR DESCRIPTION
On older Macs that have a 2880 x 1800 Retina display, setting scale_factor=2 makes the IDE far too large.  This minor logic change will only set scale to x2 if it detects both Retina and 5K.