### PR TITLE
Improves IDE highlighting of trailing $DYNAMIC/$STATIC metacommands

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -8445,8 +8445,14 @@ SUB ideshowtext
 
                 IF comment THEN
                     COLOR 11
-                    IF metacommand AND ((checkKeyword$ = "$INCLUDE" OR checkKeyword$ = "$DYNAMIC" _
-                        OR checkKeyword$ = "$STATIC") AND INSTR(m + 1, UCASE$(a2$), checkKeyword$) = 0) THEN COLOR 10
+                    IF metacommand THEN
+                        SELECT CASE checkKeyword$
+                            CASE "$INCLUDE"
+                                IF INSTR(m + 1, UCASE$(a2$), checkKeyword$) = 0 THEN COLOR 10
+                            CASE "$DYNAMIC", "$STATIC"
+                                IF INSTR(m + 1, UCASE$(a2$), "$DYNAMIC") = 0 AND INSTR(m + 1, UCASE$(a2$), "$STATIC") = 0 THEN COLOR 10
+                        END SELECT
+                    END IF
                 ELSEIF metacommand THEN
                     COLOR 10
                 ELSEIF inquote OR thisChar$ = CHR$(34) THEN


### PR DESCRIPTION
Only one of $DYNAMIC or $STATIC is processed, the last appearing in a
metacommand line, so highlight only that rather than the last appearance
of each.

Improves commmit af2752602f77845dc40c84ec13f0caa7dfdd08aa.

I'm not sure how idiomatic this is, let me know if it needs changing. E.g., it seems common to repeat the function calls rather than storing intermediate values?