### PR TITLE
Fixes whitespace of missing source file error message

### DIFF
--- a/source/qb64.bas
+++ b/source/qb64.bas
@@ -1550,7 +1550,7 @@ IF idemode = 0 THEN
     qberrorhappened1:
     IF qberrorhappened = 1 THEN
         PRINT
-        PRINT "Cannot locate source file:" + sourcefile$
+        PRINT "Cannot locate source file: " + sourcefile$
         IF ConsoleMode THEN SYSTEM 1
         END 1
     ELSE


### PR DESCRIPTION
This makes the message prettier and match the other one.

I'm going to walk on by the duplication for now.  Let's put it down to the bystander effect...a terrible thing.