### PR TITLE
Fixes "missing file" messages when purging precompiled content (WIP)

### DIFF
--- a/internal/c/purge_all_precompiled_content_lnx.sh
+++ b/internal/c/purge_all_precompiled_content_lnx.sh
@@ -1,32 +1,32 @@
 #!/bin/sh
 
-rm libqb/os/win/*.o
-rm libqb/os/lnx/*.o
+rm -f libqb/os/win/*.o
+rm -f libqb/os/lnx/*.o
 
-rm parts/core/os/win/src.a
-rm parts/core/os/lnx/src.a
-rm parts/core/os/win/temp/*.o
-rm parts/core/os/lnx/temp/*.o
+rm -f parts/core/os/win/src.a
+rm -f parts/core/os/lnx/src.a
+rm -f parts/core/os/win/temp/*.o
+rm -f parts/core/os/lnx/temp/*.o
 
-rm parts/audio/decode/mp3/os/win/src.a
-rm parts/audio/decode/mp3/os/lnx/src.a
-rm parts/audio/decode/mp3/os/win/temp/*.o
-rm parts/audio/decode/mp3/os/lnx/temp/*.o
+rm -f parts/audio/decode/mp3/os/win/src.a
+rm -f parts/audio/decode/mp3/os/lnx/src.a
+rm -f parts/audio/decode/mp3/os/win/temp/*.o
+rm -f parts/audio/decode/mp3/os/lnx/temp/*.o
 
-rm parts/audio/decode/ogg/os/win/src.o
-rm parts/audio/decode/ogg/os/lnx/src.o
-rm parts/audio/decode/ogg/os/win/temp/*.o
-rm parts/audio/decode/ogg/os/lnx/temp/*.o
+rm -f parts/audio/decode/ogg/os/win/src.o
+rm -f parts/audio/decode/ogg/os/lnx/src.o
+rm -f parts/audio/decode/ogg/os/win/temp/*.o
+rm -f parts/audio/decode/ogg/os/lnx/temp/*.o
 
-rm parts/audio/conversion/os/win/src.a
-rm parts/audio/conversion/os/lnx/src.a
-rm parts/audio/conversion/os/win/temp/*.o
-rm parts/audio/conversion/os/lnx/temp/*.o
+rm -f parts/audio/conversion/os/win/src.a
+rm -f parts/audio/conversion/os/lnx/src.a
+rm -f parts/audio/conversion/os/win/temp/*.o
+rm -f parts/audio/conversion/os/lnx/temp/*.o
 
-rm parts/audio/out/os/win/src.a
-rm parts/audio/out/os/lnx/src.a
-rm parts/audio/out/os/win/temp/*.o
-rm parts/audio/out/os/lnx/temp/*.o
+rm -f parts/audio/out/os/win/src.a
+rm -f parts/audio/out/os/lnx/src.a
+rm -f parts/audio/out/os/win/temp/*.o
+rm -f parts/audio/out/os/lnx/temp/*.o
 
-rm parts/video/font/ttf/os/win/src.o
-rm parts/video/font/ttf/os/lnx/src.o
+rm -f parts/video/font/ttf/os/win/src.o
+rm -f parts/video/font/ttf/os/lnx/src.o

--- a/internal/c/purge_all_precompiled_content_osx.command
+++ b/internal/c/purge_all_precompiled_content_osx.command
@@ -1,32 +1,32 @@
 cd "$(dirname "$0")"
 
-rm libqb/os/win/*.o
-rm libqb/os/osx/*.o
+rm -f libqb/os/win/*.o
+rm -f libqb/os/osx/*.o
 
-rm parts/core/os/win/src.a
-rm parts/core/os/osx/src.a
-rm parts/core/os/win/temp/*.o
-rm parts/core/os/osx/temp/*.o
+rm -f parts/core/os/win/src.a
+rm -f parts/core/os/osx/src.a
+rm -f parts/core/os/win/temp/*.o
+rm -f parts/core/os/osx/temp/*.o
 
-rm parts/audio/decode/mp3/os/win/src.a
-rm parts/audio/decode/mp3/os/osx/src.a
-rm parts/audio/decode/mp3/os/win/temp/*.o
-rm parts/audio/decode/mp3/os/osx/temp/*.o
+rm -f parts/audio/decode/mp3/os/win/src.a
+rm -f parts/audio/decode/mp3/os/osx/src.a
+rm -f parts/audio/decode/mp3/os/win/temp/*.o
+rm -f parts/audio/decode/mp3/os/osx/temp/*.o
 
-rm parts/audio/decode/ogg/os/win/src.o
-rm parts/audio/decode/ogg/os/osx/src.o
-rm parts/audio/decode/ogg/os/win/temp/*.o
-rm parts/audio/decode/ogg/os/osx/temp/*.o
+rm -f parts/audio/decode/ogg/os/win/src.o
+rm -f parts/audio/decode/ogg/os/osx/src.o
+rm -f parts/audio/decode/ogg/os/win/temp/*.o
+rm -f parts/audio/decode/ogg/os/osx/temp/*.o
 
-rm parts/audio/conversion/os/win/src.a
-rm parts/audio/conversion/os/osx/src.a
-rm parts/audio/conversion/os/win/temp/*.o
-rm parts/audio/conversion/os/osx/temp/*.o
+rm -f parts/audio/conversion/os/win/src.a
+rm -f parts/audio/conversion/os/osx/src.a
+rm -f parts/audio/conversion/os/win/temp/*.o
+rm -f parts/audio/conversion/os/osx/temp/*.o
 
-rm parts/audio/out/os/win/src.a
-rm parts/audio/out/os/osx/src.a
-rm parts/audio/out/os/win/temp/*.o
-rm parts/audio/out/os/osx/temp/*.o
+rm -f parts/audio/out/os/win/src.a
+rm -f parts/audio/out/os/osx/src.a
+rm -f parts/audio/out/os/win/temp/*.o
+rm -f parts/audio/out/os/osx/temp/*.o
 
-rm parts/video/font/ttf/os/win/src.o
-rm parts/video/font/ttf/os/osx/src.o
+rm -f parts/video/font/ttf/os/win/src.o
+rm -f parts/video/font/ttf/os/osx/src.o


### PR DESCRIPTION
Is there a reason to have both `purge_all_precompiled_content_lnx.sh` and `purge_all_precompiled_content.sh` and likewise for the other platform variants?  I can't find a reference to the latter versions in the repository.

`purge_libqb_only.bat` doesn't appear to be referenced either.

I assume the Windows version should add /f to the del command but I can't test that at the moment.