### PR TITLE
Fixes sloppy parsing of array parameters in sub definitions

### DIFF
--- a/source/qb64.bas
+++ b/source/qb64.bas
@@ -4862,6 +4862,7 @@ DO
                             IF t2$ = "" THEN t2$ = e$ ELSE t2$ = t2$ + " " + e$
                             gotaa2:
                         NEXT i2
+                        IF m = 1 THEN a$ = "Syntax error": GOTO errmes
                         IF symbol2$ <> "" AND t2$ <> "" THEN a$ = "Syntax error": GOTO errmes
 
 


### PR DESCRIPTION
Currently the compiler parses the following without error.

`sub foo(bar(): end sub`

This Two Minute Fix™ now produces a syntax error for the missing closing parenthesis of the parameter list.  Someone more familiar with that code may come up with a better fix.