### PR TITLE
Fixes to libqb.cpp for random file record length and to msbin.c for MBF encoding

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -13037,7 +13037,7 @@ void sub_open(qbs *name,int32 type,int32 access,int32 sharing,int32 i,int64 reco
     if (type==1){//set record length
         f->record_length=128;
         if (passed) if (record_length!=-1) f->record_length=record_length;
-        f->field_buffer=(uint8*)calloc(record_length,1);
+        f->field_buffer=(uint8*)calloc(f->record_length,1);
     }
     
     if (type==5){//seek eof

--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -13037,7 +13037,7 @@ void sub_open(qbs *name,int32 type,int32 access,int32 sharing,int32 i,int64 reco
     if (type==1){//set record length
         f->record_length=128;
         if (passed) if (record_length!=-1) f->record_length=record_length;
-        f->field_buffer=(uint8*)calloc(f->record_length,1);
+        f->field_buffer=(uint8*)calloc(record_length,1);
     }
     
     if (type==5){//seek eof
@@ -15796,11 +15796,8 @@ void sub_put2(int32 i,int64 offset,void *element,int32 passed){
         //returns a string to advance to the horizontal position "pos" on either
         //the current line or the next line.
         static int32 w,div,cursor;
-  
-        static int32 cr_size;         // a local in case file is SCRN
-        cr_size = tab_spc_cr_size;    // init to caller's value
         //calculate width in spaces & current position
-        if (cr_size==2){
+        if (tab_spc_cr_size==2){
             //print to file
             div=1;
             w=2147483647;
@@ -15811,14 +15808,9 @@ void sub_put2(int32 i,int64 offset,void *element,int32 passed){
             if (i<0) goto invalid_file;//TCP/IP unsupported
             if (gfs_fileno_valid(i)!=1) goto invalid_file;//Bad file name or number
             i=gfs_fileno[i];//convert fileno to gfs index
-            if (gfs_file[i].scrn == 1) {    // going to screen, change the cr size
-                cr_size = 1;
-            } else {
-                cursor=gfs_file[i].column;
-            }
+            cursor=gfs_file[i].column;
             invalid_file:;
-        }
-        if (cr_size == 1) {
+            }else{
             //print to surface
             if (write_page->text){
                 w=write_page->width;
@@ -15848,7 +15840,7 @@ void sub_put2(int32 i,int64 offset,void *element,int32 passed){
         size=0; spaces=0; cr=0;
         if (cursor>pos){
             cr=1;
-            size=cr_size;
+            size=tab_spc_cr_size;
             spaces=pos/div; if (pos%div) spaces++;
             spaces--;//don't put a space on the dest position
             size+=spaces;
@@ -15859,8 +15851,8 @@ void sub_put2(int32 i,int64 offset,void *element,int32 passed){
         //build custom string
         tqbs=qbs_new(size,1);
         if (cr){
-            tqbs->chr[0]=13; if (cr_size==2) tqbs->chr[1]=10;
-            memset(&tqbs->chr[cr_size],32,spaces);
+            tqbs->chr[0]=13; if (tab_spc_cr_size==2) tqbs->chr[1]=10;
+            memset(&tqbs->chr[tab_spc_cr_size],32,spaces);
             }else{
             memset(tqbs->chr,32,spaces);
         }

--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -13037,7 +13037,7 @@ void sub_open(qbs *name,int32 type,int32 access,int32 sharing,int32 i,int64 reco
     if (type==1){//set record length
         f->record_length=128;
         if (passed) if (record_length!=-1) f->record_length=record_length;
-        f->field_buffer=(uint8*)calloc(record_length,1);
+        f->field_buffer=(uint8*)calloc(f->record_length,1);
     }
     
     if (type==5){//seek eof
@@ -15796,8 +15796,11 @@ void sub_put2(int32 i,int64 offset,void *element,int32 passed){
         //returns a string to advance to the horizontal position "pos" on either
         //the current line or the next line.
         static int32 w,div,cursor;
+  
+        static int32 cr_size;         // a local in case file is SCRN
+        cr_size = tab_spc_cr_size;    // init to caller's value
         //calculate width in spaces & current position
-        if (tab_spc_cr_size==2){
+        if (cr_size==2){
             //print to file
             div=1;
             w=2147483647;
@@ -15808,9 +15811,14 @@ void sub_put2(int32 i,int64 offset,void *element,int32 passed){
             if (i<0) goto invalid_file;//TCP/IP unsupported
             if (gfs_fileno_valid(i)!=1) goto invalid_file;//Bad file name or number
             i=gfs_fileno[i];//convert fileno to gfs index
-            cursor=gfs_file[i].column;
+            if (gfs_file[i].scrn == 1) {    // going to screen, change the cr size
+                cr_size = 1;
+            } else {
+                cursor=gfs_file[i].column;
+            }
             invalid_file:;
-            }else{
+        }
+        if (cr_size == 1) {
             //print to surface
             if (write_page->text){
                 w=write_page->width;
@@ -15840,7 +15848,7 @@ void sub_put2(int32 i,int64 offset,void *element,int32 passed){
         size=0; spaces=0; cr=0;
         if (cursor>pos){
             cr=1;
-            size=tab_spc_cr_size;
+            size=cr_size;
             spaces=pos/div; if (pos%div) spaces++;
             spaces--;//don't put a space on the dest position
             size+=spaces;
@@ -15851,8 +15859,8 @@ void sub_put2(int32 i,int64 offset,void *element,int32 passed){
         //build custom string
         tqbs=qbs_new(size,1);
         if (cr){
-            tqbs->chr[0]=13; if (tab_spc_cr_size==2) tqbs->chr[1]=10;
-            memset(&tqbs->chr[tab_spc_cr_size],32,spaces);
+            tqbs->chr[0]=13; if (cr_size==2) tqbs->chr[1]=10;
+            memset(&tqbs->chr[cr_size],32,spaces);
             }else{
             memset(tqbs->chr,32,spaces);
         }

--- a/internal/c/msbin.c
+++ b/internal/c/msbin.c
@@ -214,7 +214,7 @@ int32 _dieeetomsbin(double *src8, double *dest8)
     /* Make a clobberable copy of the source number */ 
     memcpy(ieee,src8,8); //strncpy((char *)ieee,(char *)src8,8);
     
-    for (i=0; i<8; i++) msbin[i] = 0;
+   memset(msbin, 0, sizeof(*dest8)); //for (i=0; i<8; i++) msbin[i] = 0;
     
     /* If all are zero in src8, the msbin should be zero */
     for (i=0; i<8; i++) any_on |= ieee[i];
@@ -222,12 +222,15 @@ int32 _dieeetomsbin(double *src8, double *dest8)
     
     sign = ieee[7] & 0x80;
     msbin[6] |= sign;
-    msbin_exp = (unsigned)(ieee[7] & 0x7f) * 0x10;
+   msbin_exp = (unsigned)(ieee[7] & 0x7f) << 4;	//(unsigned)(ieee[7] & 0x7f) * 0x10;
     msbin_exp += ieee[6] >> 4;
     
-    if (msbin_exp-0x3ff > 0x80) return 1;
-    
-    msbin[7] = msbin_exp - 0x3ff + 0x80 + 1; 
+   // verify the exponent is in range for MBF encoding
+   msbin_exp = msbin_exp - 0x3ff + 0x80 + 1;
+   if ((msbin_exp & 0xff00) != 0) return 1;
+   msbin[7] = msbin_exp;
+   // if (msbin_exp-0x3ff > 0x80) return 1;
+   // msbin[7] = msbin_exp - 0x3ff + 0x80 + 1; 
     
     /* The ieee mantissa must be shifted up 3 bits */
     ieee[6] &= 0x0f; /* mask out the exponent in the second byte    */


### PR DESCRIPTION
I have fixed 2 bugs encountered during testing with some old QB45 code.

libqb.cpp: When opening a file for random access, if the LEN is not supplied, it defaults the length correctly, but does not allocate the buffer correctly. The code should reference the record_length in the file struct.  I believe this may also address bug report #62

msbin.c: The processing for MKDMBF$ fails for numbers smaller than 1.  Basic cause is the check for exponent overflow is incorrect. Changed code to correctly check for exponent overflow