### PR TITLE
Fix new bug with _Width and _Height

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -18838,7 +18838,7 @@ void sub_put2(int32 i,int64 offset,void *element,int32 passed){
             if (new_error) return 0;
 
             #ifdef QB64_WINDOWS
-                if (i==console_image){
+                if ((read_page->console && !passed)||i==console_image){
                     SECURITY_ATTRIBUTES SecAttribs = {sizeof(SECURITY_ATTRIBUTES), 0, 1};
                     HANDLE cl_conout = CreateFileA("CONOUT$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, & SecAttribs, OPEN_EXISTING, 0, 0);
                     CONSOLE_SCREEN_BUFFER_INFO cl_bufinfo;
@@ -18867,7 +18867,7 @@ void sub_put2(int32 i,int64 offset,void *element,int32 passed){
             if (new_error) return 0;
 
             #ifdef QB64_WINDOWS
-                if (i==console_image){
+                if ((read_page->console && !passed)||i==console_image){
                     SECURITY_ATTRIBUTES SecAttribs = {sizeof(SECURITY_ATTRIBUTES), 0, 1};
                     HANDLE cl_conout = CreateFileA("CONOUT$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, & SecAttribs, OPEN_EXISTING, 0, 0);
                     CONSOLE_SCREEN_BUFFER_INFO cl_bufinfo;


### PR DESCRIPTION
Where the previous bug would only return the console's image size when an image was passed, the new bug made it only ever return 80 for `_Width` and 25 for `_Height` when it should be returning the console's image size if there is no value passed and it is the `_Source`, which it is if we are in a `$Console:Only`.

Here is a code block that demonstrates the bug being fixed:
```
Option _Explicit
$Console
Screen _NewImage(640, 480, 32)
_Dest _Console
Width 120, 5
_Dest 0

Print "Hello world"

Print _DesktopWidth, _DesktopHeight
Dim As Long i: i = _NewImage(1280, 720, 32)
Print _Width, _Height
Print _Width(0), _Height(0)
Print _Width(i), _Height(i)
Print _Width(_Console), _Height(_Console)
```