### PR TITLE
Fix: Ambigous 'data' in global scope

### DIFF
--- a/internal/c/common.h
+++ b/internal/c/common.h
@@ -100,7 +100,6 @@
         #endif
     #endif
     
-    using namespace std;
     
     //QB64 string descriptor structure
     struct qbs_field{


### PR DESCRIPTION
Fixes #184
Probably breaks another thing.
Ambigous 'data' in global scope
https://root-forum.cern.ch/t/ambiguous-data-in-global-scope/41490