### PR TITLE
Fix: #184 and PR #185

### DIFF
--- a/internal/c/common.h
+++ b/internal/c/common.h
@@ -100,7 +100,6 @@
         #endif
     #endif
     
-    using namespace std;
     
     //QB64 string descriptor structure
     struct qbs_field{

--- a/internal/c/libqb.h
+++ b/internal/c/libqb.h
@@ -68,4 +68,6 @@
     
     extern qbs *qbs_lcase(qbs *str);
     extern qbs *qbs_ucase(qbs *str);
+
+    using namespace std;
 #endif


### PR DESCRIPTION
Sorry to bother you again, but:
This fixes #184 and the errors in PR #185 are gone:

> Compiling and installing QB64...
> Building library 'LibQB'
> Building library 'FreeType'
> Building library 'Core:FreeGLUT'
> Building 'QB64'
> ~/Downloads/qb64
> Done compiling!!
> Creating ./run_qb64.sh script...
> Adding QB64 menu entry...
> Running QB64...
> QB64 is located in this folder:
> /home/chlorophyll-zz/Downloads/qb64
> There is a ./run_qb64.sh script in this folder that should let you run qb64 if using the executable directly isn't working.
> 
> You should also find a QB64 option in the Programming/Development section of your menu you can use.
> 
> Thank you for using the QB64 installer.
> 