### PR TITLE
Disambiguate bind call in libqb.cpp to allow building on OSX High Sierra 10.13

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -21672,7 +21672,7 @@ void sub_put2(int32 i,int64 offset,void *element,int32 passed){
                     sockfd = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
                     if (sockfd == -1) continue;
                     setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
-                    if (bind(sockfd, p->ai_addr, p->ai_addrlen) == -1) {
+                    if (::bind(sockfd, p->ai_addr, p->ai_addrlen) == -1) {
                         close(sockfd);
                         continue;
                     }


### PR DESCRIPTION
Since libqb.h uses namespace std, the bind call in libqb.cpp can be confused with \<functional\> `std::bind`, which prevented me from building on Mac OS high Sierra 10.13. So I added the global scope operator :: to the bind call to prevent clashes. 